### PR TITLE
Fix a missing comma

### DIFF
--- a/src/pages/7-uses-for-css-custom-properties.md
+++ b/src/pages/7-uses-for-css-custom-properties.md
@@ -35,7 +35,7 @@ If you’re using a shorthand property such as `animation`, and you need to chan
 
 ```css
 .some-element {
-  animation: var(--animationName, pulse) var(--duration 2000ms) ease-in-out
+  animation: var(--animationName, pulse) var(--duration, 2000ms) ease-in-out
     infinite;
 }
 


### PR DESCRIPTION
I think the comma is mandatory between the property name and the default value, isn't it?